### PR TITLE
remove blocking when brotli is not supported and add blocking when gzip and deflate aren't supported

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -71,8 +71,18 @@
                 ]
             },
             {
-                "name": "block no brotli support",
-                "filters": ["!Header:Accept-Encoding=[; ]?br[; ]?"],
+                "name": "block no gzip support",
+                "filters": ["!Header:Accept-Encoding=(^gzip$|^gzip[;,]|[; ]gzip$|[; ]gzip[;,])"],
+                "limit": 0,
+                "stop": true,
+                "actions": [
+                    {"name": "block",
+                     "params": {"message": "Rate limit exceeded"}}
+                ]
+            },
+            {
+                "name": "block no deflate support",
+                "filters": ["!Header:Accept-Encoding=(^deflate$|^deflate[;,]|[; ]deflate$|[; ]deflate[;,])"],
                 "limit": 0,
                 "stop": true,
                 "actions": [


### PR DESCRIPTION
Some browsers like OH Browser and Naked Browser (which internally use Android webkit) doesn't support brotli and thus are being blocked as a false positive.

I know this specific rule really helps to block bots because a vast majority of bots doesn't support brotli nor fake that header but meanwhile it restricts some users that are using barebone browsers like the ones mentioned previously.

I'm open to discuss this PR and maybe replace the rule with another one that blocks if the value `gzip, deflate` is not present in the header `Accept-Encoding`.