### PR TITLE
[fix] rules.json: allow Firefox Android to add searx

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -34,9 +34,8 @@
                 "name": "allow Firefox Android (issue #48)",
                 "filters": [
                     "Param:q=^1$",
-                    "Header:User-Agent=^MozacFetch/[0-9]{2,3}.[0-9].[0-9]+$",
-                    "Header:Accept=^\\*/\\*$",
-                    "Header:Accept-Language=^\\*/\\*$"],
+                    "Header:User-Agent=^MozacFetch/[0-9]{2,3}.[0-9].[0-9]+$"
+                ],
                 "stop": true,
                 "actions": [{"name": "log"}]
             },

--- a/rules.json
+++ b/rules.json
@@ -31,6 +31,16 @@
         "filters": ["Param:q", "Path=^(/|/search)$"],
         "subrules": [
             {
+                "name": "allow Firefox Android (issue #48)",
+                "filters": [
+                    "Param:q=^1$",
+                    "Header:User-Agent=^MozacFetch/[0-9]{2,3}.[0-9].[0-9]+$",
+                    "Header:Accept=^\\*/\\*$",
+                    "Header:Accept-Language=^\\*/\\*$"],
+                "stop": true,
+                "actions": [{"name": "log"}]
+            },
+            {
                 "name": "robot agent forbidden",
                 "limit": 0,
                 "stop": true,


### PR DESCRIPTION
fix #48

User agent:
* Beta: ```MozacFetch/48.0.5```
* Nightly: ```MozacFetch/52.0.20200725130253```

About the filters:
* ```"Param:q=^1$"``` with ^ and $ to allow only ```1``` not ```<anything> 1```. 
* ~~same for ```Accept``` and ```Accept-Language```~~ [EDIT] removed