### PR TITLE
Fix morty not binding to 0.0.0.0 by changing docker-compose.yaml and using environment variable

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,9 +66,10 @@ services:
       - "127.0.0.1:3000:3000"
     networks:
       - searx
-    command: -listen 0.0.0.0:3000 -timeout 6 -ipv6
+    command: -timeout 6 -ipv6
     environment:
       - MORTY_KEY=${MORTY_KEY}
+      - MORTY_ADDRESS=0.0.0.0:3000
     logging:
       driver: none
     read_only: true


### PR DESCRIPTION
Please see #18 

I am not sure if it's worth merging this, or if @dalf would like to look at the dalf/morty docker image to see if there's any changes that would make more sense.

Thanks @mauvity for finding the fix.