### PR TITLE
Fix Searx as a search engine on Firefox android

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -31,10 +31,10 @@
         "filters": ["Param:q", "Path=^(/|/search)$"],
         "subrules": [
             {
-                "name": "allow Firefox Android (issue #48)",
+                "name": "allow Firefox Android (issue #48 and #60)",
                 "filters": [
                     "Param:q=^1$",
-                    "Header:User-Agent=^MozacFetch/[0-9]{2,3}.[0-9].[0-9]+$"
+                    "Header:User-Agent=(^MozacFetch/[0-9]{2,3}.[0-9].[0-9]+$|^Mozilla/5.0 \\(Android [0-9]{1,2}(.[0-9]{1,2}.[0-9]{1,2})?; Mobile; rv:[0-9]{2,3}.[0-9]\\) Gecko/[0-9]{2,3}.[0-9] Firefox/[0-9]{2,3}.[0-9]$)"
                 ],
                 "stop": true,
                 "actions": [{"name": "log"}]


### PR DESCRIPTION
This PR fixes #60.

Summary:
The user agent when adding Searx as a search engine has changed to a similar one like this one: "Mozilla/5.0 (Android 9; Mobile; rv:83.0) Gecko/83.0 Firefox/83.0".
A backward compatibility with older versions of Firefox android is also included.

@dalf Could you check if my regex is good? I'm not a regex master, so I may have badly written it.

regex101 test sample: https://regex101.com/r/CL0Vx7/1