### PR TITLE
Add Permissions-Policy HTTP header to Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -44,6 +44,9 @@
         X-Frame-Options "SAMEORIGIN"
 
         # Disable some features
+        Permissions-Policy "accelerometer=();ambient-light-sensor=(); autoplay=();camera=();encrypted-media=();focus-without-user-activation=(); geolocation=();gyroscope=();magnetometer=();microphone=();midi=();payment=();picture-in-picture=(); speaker=();sync-xhr=();usb=();vr=()"
+
+        # Disable some features (legacy)
         Feature-Policy "accelerometer 'none';ambient-light-sensor 'none'; autoplay 'none';camera 'none';encrypted-media 'none';focus-without-user-activation 'none'; geolocation 'none';gyroscope 'none';magnetometer 'none';microphone 'none';midi 'none';payment 'none';picture-in-picture 'none'; speaker 'none';sync-xhr 'none';usb 'none';vr 'none'"
 
         # Referer


### PR DESCRIPTION
The Feature-Policy header was renamed to Permissions-Policy. This PR adds the new header to the Caddyfile while keeping Feature-Policy for legacy purposes.

See: https://scotthelme.co.uk/goodbye-feature-policy-and-hello-permissions-policy/