### PR TITLE
Added Generate MORTY_KEY step to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ cd /usr/local
 git clone https://github.com/searx/searx-docker.git
 cd searx-docker
 ```
-- Edit the [.env](https://github.com/searx/searx-docker/blob/master/.env) file according to your need
+- Generate MORTY_KEY ```sed -i "s/ReplaceWithARealKey\!/$(openssl rand -base64 33)/g" .env```
+- Edit the other settings in [.env](https://github.com/searx/searx-docker/blob/master/.env) file according to your need
 - Check everything is working: ```./start.sh```,
 - ```cp searx-docker.service.template searx-docker.service```
 - edit the content of ```WorkingDirectory``` in the ```searx-docker.service``` file (only if the installation path is different from /usr/local/searx-docker)


### PR DESCRIPTION
Hi,
I followed the step in `README.md` but the the morty container fails to start and the searx container responds with "Internal Server Error".

As a new user it wasn't obvious that I needed to generate the `MORTY_KEY` before running `start.sh`

This PR updates `README.md` with a step to generate the key

