### PR TITLE
Replace sed separator with pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cd /usr/local
 git clone https://github.com/searx/searx-docker.git
 cd searx-docker
 ```
-- Generate MORTY_KEY ```sed -i "s/ReplaceWithARealKey\!/$(openssl rand -base64 33)/g" .env```
+- Generate MORTY_KEY ```sed -i "s|ReplaceWithARealKey\!|$(openssl rand -base64 33)|g" .env```
 - Edit the other settings in [.env](https://github.com/searx/searx-docker/blob/master/.env) file according to your need
 - Check everything is working: ```./start.sh```,
 - ```cp searx-docker.service.template searx-docker.service```


### PR DESCRIPTION
## Summary
base64 random key may contain the `/`  character, which conflicts with the sed separator, using `|` as the separator fixes it.

---

### Example error

```bash
searx-docker# sed -i "s/ReplaceWithARealKey\!/$(openssl rand -base64 33)/g" .env
sed: -e expression #1, char 53: unknown option to `s'
```

### Example key that caused the error

```
qlhRzleI9oYXgHYn34eyV7LbHJP/Qsw+OLXqptd2Jq4i
```
